### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This changelog will be corrected in the future.
 
+## v0.0.15
+
+* fix [#14](https://github.com/charles-m-knox/firefox-containers-helper/issues/14), to use non-localized AMO links
+* fix [#15](https://github.com/charles-m-knox/firefox-containers-helper/issues/15), to enable Mac support for anything that uses the `Ctrl` key modifier to allow the `Meta` (`Cmd` key) modifier to work as well
+* minor change: set text color to white when items are selected; previously text was black and the background highlight color was also dark gray, making it hard to see
+* on Mac, the default shortcut key (`Alt+Shift+D`) is overridden by a built-in shortcut, so the new shortcut key on Mac is `Command+Shift+E`. You can change this if you want.
+
 ## v0.0.12-v0.0.14
 
 * fix [#11](https://github.com/charles-m-knox/firefox-containers-helper/issues/11), the indexing for multi-select was using the total number of containers instead of the filtered number of containers 😰

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ With [Total Cookie Protection](https://blog.mozilla.org/security/2021/02/23/tota
 * **Keyboard shortcut** to open the popup window is `alt+shift+D` (configurable). It will immediately focus the search box, so you can quickly filter for a container, press enter, and go.
 * **Dark and Light mode** - respects your system's dark/light mode setting, thanks to [KerfuffleV2](https://github.com/charles-m-knox/firefox-containers-helper/issues?q=is%3Apr+author%3AKerfuffleV2) in [PR #8](https://github.com/charles-m-knox/firefox-containers-helper/pull/8)
   * Note: On my Ubuntu system, changing Firefox's theme isn't enough, I had to change my entire theme from a dark theme to a light theme to switch the preference
-* **Select Mode** - Like you'd intuitively expect, you can enable Select Mode press `Ctrl+Click` to specifically select a couple results from the list, as well as `Ctrl+Shift+Click` to traverse a range of containers.
+* **Select Mode** - Like you'd intuitively expect, you can enable Select Mode press `Ctrl+Click` (`Cmd+Click` on Mac) to specifically select a couple results from the list, as well as `Ctrl+Shift+Click` (`Cmd+Shift+Click` on Mac) to traverse a range of containers.
 * **Container Quick-Add** - Allows you to quickly add a new container based on what you have typed into the filter text box. Defaults to a circle icon and the toolbar color.
 
 ## Examples and Screenshots
@@ -78,7 +78,7 @@ If any of this is confusing, remember the basics:
 
 * Press `shift` and click/enter to act on ALL results (bulk open tab/delete container/set URL action)
 * Press `ctrl` and click/enter a result to open as pinned tab(s)
-  * Note that entering *Select Mode* will change the behavior of `ctrl+click` to specifically select one container from the list, or multiple if `shift` is also held
+  * Note that entering *Select Mode* will change the behavior of `ctrl+click` (`Cmd+Click` on Mac) to specifically select one container from the list, or multiple if `shift` is also held
 
 ### v0.0.11 Examples
 
@@ -86,7 +86,7 @@ In v0.0.11, the features introduced were:
 
 * **Dark and Light mode** - [Bootstrap dark mode](https://github.com/vinorodrigues/bootstrap-dark) which respects your system theme preference
   * Note: On my Ubuntu system, changing Firefox's theme wasn't enough, I had to change my entire theme from a dark theme to a light theme to switch the preference
-* **Select Mode** - Allows you to precisely select only a couple results from the list by first enabling the mode and then pressing `Ctrl+Click`, or multiple by pressing `Ctrl+Shift+Click`
+* **Select Mode** - Allows you to precisely select only a couple results from the list by first enabling the mode and then pressing `Ctrl+Click` (`Cmd+Click` on Mac), or multiple by pressing `Ctrl+Shift+Click`
 * **Configurable Keyboard Shortcut** - Allows you to change the keyboard shortcut for showing the extension popup window, which is by default `Alt+Shift+D`. This fixes [#4](https://github.com/charles-m-knox/firefox-containers-helper/issues/4)
 * **Container Quick-Add** - Allows you to quickly add a new container based on what you have typed into the filter text box. Defaults to a circle icon and the toolbar color
 
@@ -97,8 +97,8 @@ In v0.0.11, the features introduced were:
 In this example, a few features are showcased:
 
 * First, notice the **dark mode theme**.
-* **Multi-select** - Select and open multiple specific tabs using `Ctrl+Click`
-* **Multi-select over a range** - Select and open multiple specific tabs using `Ctrl+Shift+Click`
+* **Multi-select** - Select and open multiple specific tabs using `Ctrl+Click` (`Cmd+Click` on Mac)
+* **Multi-select over a range** - Select and open multiple specific tabs using `Ctrl+Shift+Click` (`Cmd+Shift+Click` on Mac)
 * **Container quick-add** - Quickly add a bunch of containers by typing in a name into the search box
 
 ![v0.0.11 usage example](readme-assets/v0.0.11/v0.0.11.gif)

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ You can support the author directly [here](https://charlesmknox.com/about), and 
 
 ## Repository source code update
 
-This repository used to be hosted on GitLab. For all releases before and including v0.0.10, please use the [GitLab releases page](https://gitlab.com/icode331/firefox-containers-helper), or use the [official Firefox Addons Store URL](https://addons.mozilla.org/en-US/firefox/addon/containers-helper/).
+This repository used to be hosted on GitLab. For all releases before and including v0.0.10, please use the [GitLab releases page](https://gitlab.com/icode331/firefox-containers-helper), or use the [official Firefox Addons Store URL](https://addons.mozilla.org/addon/containers-helper).
 
 ## Attributions
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ With [Total Cookie Protection](https://blog.mozilla.org/security/2021/02/23/tota
 * **Deletion mode** - When checked, you can click on a container to delete it. This method of deletion is a bit quicker than the multi-account containers extension. You will be prompted for deletion more than once.
   * **Caution: This can delete all of your containers if you're not careful.**
   * Similar to above, press `shift` to bulk-delete containers returned by a query.
-* **Keyboard shortcut** to open the popup window is `alt+shift+D` (configurable). It will immediately focus the search box, so you can quickly filter for a container, press enter, and go.
+* **Keyboard shortcut** to open the popup window is `alt+shift+D` (configurable, on Mac it is `Command+Shift+E`). It will immediately focus the search box, so you can quickly filter for a container, press enter, and go.
 * **Dark and Light mode** - respects your system's dark/light mode setting, thanks to [KerfuffleV2](https://github.com/charles-m-knox/firefox-containers-helper/issues?q=is%3Apr+author%3AKerfuffleV2) in [PR #8](https://github.com/charles-m-knox/firefox-containers-helper/pull/8)
   * Note: On my Ubuntu system, changing Firefox's theme isn't enough, I had to change my entire theme from a dark theme to a light theme to switch the preference
 * **Select Mode** - Like you'd intuitively expect, you can enable Select Mode press `Ctrl+Click` (`Cmd+Click` on Mac) to specifically select a couple results from the list, as well as `Ctrl+Shift+Click` (`Cmd+Shift+Click` on Mac) to traverse a range of containers.
@@ -87,7 +87,7 @@ In v0.0.11, the features introduced were:
 * **Dark and Light mode** - [Bootstrap dark mode](https://github.com/vinorodrigues/bootstrap-dark) which respects your system theme preference
   * Note: On my Ubuntu system, changing Firefox's theme wasn't enough, I had to change my entire theme from a dark theme to a light theme to switch the preference
 * **Select Mode** - Allows you to precisely select only a couple results from the list by first enabling the mode and then pressing `Ctrl+Click` (`Cmd+Click` on Mac), or multiple by pressing `Ctrl+Shift+Click`
-* **Configurable Keyboard Shortcut** - Allows you to change the keyboard shortcut for showing the extension popup window, which is by default `Alt+Shift+D`. This fixes [#4](https://github.com/charles-m-knox/firefox-containers-helper/issues/4)
+* **Configurable Keyboard Shortcut** - Allows you to change the keyboard shortcut for showing the extension popup window, which is by default `Alt+Shift+D` (on Mac it is `Command+Shift+E`). This fixes [#4](https://github.com/charles-m-knox/firefox-containers-helper/issues/4)
 * **Container Quick-Add** - Allows you to quickly add a new container based on what you have typed into the filter text box. Defaults to a circle icon and the toolbar color
 
 *See [`CHANGELOG.md`](./CHANGELOG.md) for more changes.*

--- a/src/context.js
+++ b/src/context.js
@@ -1,5 +1,11 @@
 "use strict";
 
+let platformModifierKey = 'Ctrl'; // windows, linux
+// https://stackoverflow.com/a/11752084
+if (navigator.platform.toUpperCase().indexOf('MAC') >= 0) {
+    platformModifierKey = 'Cmd'; // mac
+}
+
 // helpful links:
 // https://github.com/mdn/webextensions-examples/blob/master/favourite-colour/options.js
 // https://github.com/crazymousethief/container-plus/blob/master/context.js
@@ -169,7 +175,7 @@ const CONTEXT_ICONS = [
  */
 const helpTextMessages = [
     'Tip: Press Enter or click on a container below.',
-    'Tip: Use Ctrl(+Shift) to open pinned tab(s).',
+    `Tip: Use ${platformModifierKey}(+Shift) to open pinned tab(s).`,
     'Tip: Shift+Click to execute against every shown result'
 ];
 
@@ -190,7 +196,7 @@ const containerListItemInactiveClassNames = 'list-group-item container-list-item
  * @type {string}
  * @default
  */
-const containerListItemSelectedClassNames = 'list-group-item container-list-item d-flex justify-content-space-between align-items-center bg-secondary border-secondary';
+const containerListItemSelectedClassNames = 'list-group-item container-list-item d-flex justify-content-space-between align-items-center bg-secondary border-secondary text-white';
 
 /**
  * This is the set of classes to assign to a container list item that is
@@ -840,7 +846,7 @@ const containerClickHandler = (filteredContexts, singleContext, event) => {
     let ctrlModifier = false;
     let shiftModifier = false;
     if (event) {
-        if (event.getModifierState('Control')) {
+        if (event.getModifierState('Control') || event.getModifierState('Meta')) {
             ctrlModifier = true;
         }
         if (event.getModifierState('Shift')) {
@@ -1187,7 +1193,7 @@ const initializeDocument = (event) => {
         showModeHelpMessage();
         filterContainers();
         if (config.selectionMode) {
-            setHelpText("Use Ctrl+Click to select 1; Ctrl+Shift+Click for a range");
+            setHelpText(`${platformModifierKey}+Click to select 1; ${platformModifierKey}+Shift+Click for a range`);
         }
         focusSearchBox();
     });
@@ -1207,7 +1213,7 @@ const initializeDocument = (event) => {
         resetSelectedContexts();
         setSelectedListItemClassNames();
         if (config.selectionMode) {
-            setHelpText("Use Ctrl+Click to select 1; Ctrl+Shift+Click for a range");
+            setHelpText(`${platformModifierKey}+Click to select 1; ${platformModifierKey}+Shift+Click for a range`);
         } else {
             showModeHelpMessage();
         }

--- a/src/context.js
+++ b/src/context.js
@@ -956,26 +956,6 @@ const containerClickHandler = (filteredContexts, singleContext, event) => {
         default:
             break;
     }
-    // TODO: delete
-    // if (config.mode === MODES.SET_NAME) {
-    //     renameContexts(contextsToActOn);
-    // } else if (config.mode === MODES.DELETE) {
-    //     deleteMultipleContainers(contextsToActOn);
-    // } else if (config.mode === MODES.SET_URL) {
-    //     setMultipleDefaultUrlsWithPrompt(contextsToActOn);
-    // } else if (config.mode === MODES.SET_COLOR) {
-    //     setColorForContexts(contextsToActOn);
-    // } else if (config.mode === MODES.SET_ICON) {
-    //     setIconForContexts(contextsToActOn);
-    // } else if (config.mode === MODES.REPLACE_IN_NAME) {
-    //     findReplaceNameInContexts(contextsToActOn);
-    // } else if (config.mode === MODES.REPLACE_IN_URL) {
-    //     findReplaceUrlInContexts(contextsToActOn);
-    // } else if (config.mode === MODES.DUPLICATE) {
-    //     duplicateContexts(contextsToActOn);
-    // } else if (config.mode === MODES.OPEN) {
-    //     openMultipleContexts(contextsToActOn, shouldOpenPinnedTab);
-    // }
 
     actionCompletedHandler();
 };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Containers Helper",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "description": "Helps improve container management by providing container searching, deleting, renaming, duplicating, and default URLs on a per-container or bulk basis.",
     "icons": {
         "48": "icons/icon_cube.svg",
@@ -34,7 +34,8 @@
     "commands": {
         "_execute_browser_action": {
             "suggested_key": {
-                "default": "Alt+Shift+D"
+                "default": "Alt+Shift+D",
+                "mac": "Command+Shift+E"
             },
             "description": "Open containers helper panel"
         }


### PR DESCRIPTION
Copy/paste from changelog.

* fix [#14](https://github.com/charles-m-knox/firefox-containers-helper/issues/14), to use non-localized AMO links
* fix [#15](https://github.com/charles-m-knox/firefox-containers-helper/issues/15), to enable Mac support for anything that uses the `Ctrl` key modifier to allow the `Meta` (`Cmd` key) modifier to work as well
* minor change: set text color to white when items are selected; previously text was black and the background highlight color was also dark gray, making it hard to see
* on Mac, the default shortcut key (`Alt+Shift+D`) is overridden by a built-in shortcut, so the new shortcut key on Mac is `Command+Shift+E`. You can change this if you want.