### PR TITLE
Repositioning and tightening margins/padding in extension popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This changelog contains all relevant changes between different versions of the extension.
 
+## v0.1.2
+
+* Adjusts the CSS styling and positioning of elements in the extension popup to respect 600px max height constraints
+* Fixes scrolling on some environments
+* When opening the popup in a new tab, the full width of the screen is used
+
 ## v0.1.1
 
 * fix Enter key not working for triggering actions in popup (https://github.com/cmcode-dev/firefox-containers-helper/issues/44)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firefox-containers-helper",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "main": "index.js",
   "directories": {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -4,13 +4,14 @@
 
 .overflow-scroll-vertical {
     overflow-y: auto;
-    max-height: 300px;
-    min-height: 300px;
-    height: 300px;
+    max-height: 350px;
+    /* min-height: 300px; */
+    /* height: 300px; */
 }
 
 .container-list-text {
-    font-size: 0.9rem;
+    font-size: small;
+    /* font-size: 0.9rem; */
 }
 
 .icon {
@@ -38,7 +39,8 @@
 }
 
 #container-list {
-    min-height: 174px;
+    min-height: 200px;
+    /* min-height: 174px; */
 }
 
 .mono-16 {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -15,7 +15,7 @@
 }
 
 .icon {
-    overflow: hidden;
+    /* overflow: hidden; */
     max-height: 18px;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -4,7 +4,7 @@
 
 .overflow-scroll-vertical {
     overflow-y: auto;
-    max-height: 350px;
+    max-height: 300px;
     /* min-height: 300px; */
     /* height: 300px; */
 }
@@ -19,7 +19,7 @@
     max-height: 18px;
 }
 
-.icon>i {
+/* .icon>i {
     position: relative;
     background-size: 16px 16px;
     width: 16px;
@@ -27,7 +27,7 @@
     overflow: hidden;
     left: calc(16px * -1);
     border-right: 16px solid transparent;
-}
+} */
 
 .loading {
     display: none;

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -1,7 +1,7 @@
 body {
-    height: 600px;
-    max-height: 600px;
-    min-height: 600px;
+    /* height: 600px; */
+    /* max-height: 600px; */
+    /* min-height: 600px; */
     min-width: 330px;
     width: 330px;
     max-width: 330px;

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -1,8 +1,13 @@
 body {
-    /* height: 600px; */
-    /* max-height: 600px; */
-    /* min-height: 600px; */
+    max-height: 600px;
     min-width: 330px;
-    width: 330px;
-    max-width: 330px;
+    /* width: 330px;
+    max-width: 330px; */
+}
+
+html {
+    max-height: 600px;
+    min-width: 330px;
+    /* width: 330px;
+    max-width: 330px; */
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Containers Helper",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Helps improve container management by providing container searching, deleting, renaming, duplicating, and default URLs on a per-container or bulk basis.",
     "icons": {
         "48": "icons/icon_cube.svg",

--- a/src/modules/classes.ts
+++ b/src/modules/classes.ts
@@ -5,8 +5,8 @@ const LI_BASE = 'list-group-item d-flex justify-content-space-between align-item
 
 export const CLASSES_CONTAINER_LI = `${LI_BASE}`;
 
-export const CLASSES_CONTAINER_ICON = `px-2`;
-export const CLASSES_CONTAINER_ICON_DIV = `icon ml-2`;
+export const CLASSES_CONTAINER_ICON = ``;
+export const CLASSES_CONTAINER_ICON_DIV = `icon mx-2 pr-2`;
 
 
 export const CLASSES_CONTAINER_ICON_EMPTY_TEXT = 'mono-16';

--- a/src/modules/classes.ts
+++ b/src/modules/classes.ts
@@ -1,34 +1,62 @@
 export const CLASS_ELEMENT_HIDE = 'element-hide';
 export const CLASS_ELEMENT_SHOW = 'element-show';
 
+const LI_BASE = 'list-group-item d-flex justify-content-space-between align-items-center container-list-item m-0 p-2';
+
+export const CLASSES_CONTAINER_LI = `${LI_BASE}`;
+
+export const CLASSES_CONTAINER_ICON = `px-2`;
+export const CLASSES_CONTAINER_ICON_DIV = `icon ml-2`;
+
+
+export const CLASSES_CONTAINER_ICON_EMPTY_TEXT = 'mono-16';
+
+/**
+ * An empty set of results shows differently from the typical container list
+ * items.
+ */
+export const CLASSES_CONTAINER_LI_EMPTY = 'list-group-item d-flex justify-content-space-between align-items-center'
+
 /**
  * This is the set of classes to assign to a container list item that is not
  * currently being hovered over. Assign to `element.className` for a given element.
  */
-export const CLASSES_CONTAINER_LI_INACTIVE = 'list-group-item container-list-item d-flex justify-content-space-between align-items-center';
+export const CLASSES_CONTAINER_LI_INACTIVE = `${LI_BASE}`;
 
 /**
  * This is the set of classes to assign to a container list item that is not
  * currently being hovered over, but is selected via the selection mode.
  * Assign to `element.className` for a given element.
  */
-export const CLASSES_CONTAINER_LI_SELECTED = 'list-group-item container-list-item d-flex justify-content-space-between align-items-center bg-secondary border-secondary text-white';
+export const CLASSES_CONTAINER_LI_SELECTED = `${LI_BASE} bg-secondary border-secondary text-white`;
 
 /**
  * This is the set of classes to assign to a container list item that is
  * currently being hovered over. Assign to `element.className` for a given element.
  */
-export const CLASSES_LI_ACTIVE = `${CLASSES_CONTAINER_LI_INACTIVE} active cursor-pointer`;
+export const CLASSES_CONTAINER_LI_ACTIVE = `${CLASSES_CONTAINER_LI_INACTIVE} active cursor-pointer`;
 
 /**
  * This is the set of classes to assign to a container list item that is
  * currently being hovered over, while the container management mode is set to
  * deletion mode. Assign to `element.className` for a given element.
  */
-export const CLASSES_CONTAINER_LI_ACTIVE_DANGER = `${CLASSES_LI_ACTIVE} bg-danger border-danger`;
+export const CLASSES_CONTAINER_LI_ACTIVE_DANGER = `${CLASSES_CONTAINER_LI_ACTIVE} bg-danger border-danger`;
 
-export const CLASSES_CONTAINER_DIV = 'container-list-text d-flex flex-column justify-content-center align-items-baseline px-3';
+export const CLASSES_CONTAINER_DIV = 'container-list-text d-flex flex-column justify-content-center align-items-baseline px-0 pr-1';
 
-export const CLASSES_CONTAINER_LI = 'list-group-item d-flex justify-content-space-between align-items-center';
+export const CLASSES_CONTAINER_DIV_DESTRUCTIVE = 'd-flex justify-content-center align-items-center align-content-center';
 
-export const CLASSES_CONTAINER_LI_DIV_DESTRUCTIVE = 'd-flex justify-content-center align-items-center align-content-center';
+/**
+ * This is the set of classes to assign to a container list item url label that
+ * is currently not being hovered over or selected.
+ * Assign to `element.className` for a given element.
+ */
+export const CLASSES_CONTAINER_LI_URL_LABEL = `text-muted small`;
+
+/**
+ * This is the set of classes to assign to a container list item url label that
+ * is currently being hovered over or selected
+ * Assign to `element.className` for a given element.
+ */
+export const CLASSES_CONTAINER_LI_URL_LABEL_INVERTED = `text-light small`;

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -109,21 +109,6 @@ export enum UrlMatchTypes {
 }
 
 /**
- * This is the set of classes to assign to a container list item url label that
- * is currently not being hovered over or selected.
- * Assign to `element.className` for a given element.
- */
-export const containerListItemUrlLabel = `text-muted small`;
-
-/**
- * This is the set of classes to assign to a container list item url label that
- * is currently being hovered over or selected
- * Assign to `element.className` for a given element.
- */
-export const containerListItemUrlLabelInverted = `text-light small`;
-
-
-/**
  * The `<div>` ID of the container list. This is where all of the queried
  * containers will go.
  */

--- a/src/modules/elements.ts
+++ b/src/modules/elements.ts
@@ -4,11 +4,15 @@ import {
     CLASSES_CONTAINER_LI_INACTIVE,
     CLASSES_CONTAINER_DIV,
     CLASSES_CONTAINER_LI,
-    CLASSES_CONTAINER_LI_DIV_DESTRUCTIVE,
+    CLASSES_CONTAINER_DIV_DESTRUCTIVE,
+    CLASSES_CONTAINER_LI_EMPTY,
+    CLASSES_CONTAINER_ICON_DIV,
+    CLASSES_CONTAINER_LI_URL_LABEL_INVERTED,
+    CLASSES_CONTAINER_LI_URL_LABEL,
+    CLASSES_CONTAINER_ICON_EMPTY_TEXT,
+    CLASSES_CONTAINER_ICON
 } from "./classes";
 import {
-    containerListItemUrlLabelInverted,
-    containerListItemUrlLabel,
     MODES,
     CONF,
     UrlMatchTypes,
@@ -41,11 +45,13 @@ export const buildContainerListGroupElement = (): HTMLUListElement => {
  */
 export const buildContainerIcon = (context: browser.contextualIdentities.ContextualIdentity): HTMLDivElement => {
     const iconDiv = document.createElement('div') as HTMLDivElement;
-    iconDiv.className = 'icon';
+    iconDiv.className = CLASSES_CONTAINER_ICON_DIV;
 
     const icon = document.createElement('i') as HTMLElement;
     icon.style.backgroundImage = `url(${context.iconUrl})`;
+    icon.style.backgroundRepeat = 'no-repeat';
     icon.style.filter = `drop-shadow(${context.colorCode} 16px 0)`;
+    icon.className = CLASSES_CONTAINER_ICON;
 
     addEmptyEventListeners([iconDiv, icon]);
 
@@ -77,7 +83,7 @@ export const buildContainerLabel = async (
         nameLabel.innerText = `${context.name}`;
 
         const urlLabel = document.createElement('span') as HTMLSpanElement;
-        urlLabel.className = containerListItemUrlLabel;
+        urlLabel.className = CLASSES_CONTAINER_LI_URL_LABEL;
         urlLabel.id = `filtered-context-${i}-url-label`;
 
         const urls = await getSetting(CONF.containerDefaultUrls) as ContainerDefaultURL;
@@ -188,7 +194,7 @@ export const buildContainerListItem = async (
         if (mode === MODES.DELETE || mode === MODES.REFRESH) {
             const div = document.createElement('div') as HTMLDivElement;
 
-            div.className = CLASSES_CONTAINER_LI_DIV_DESTRUCTIVE;
+            div.className = CLASSES_CONTAINER_DIV_DESTRUCTIVE;
             div.id = `filtered-context-${i}-div`;
 
             addEmptyEventListeners([div]);
@@ -227,12 +233,12 @@ export const buildContainerListItem = async (
  */
 export const buildContainerListItemEmpty = (i: number): HTMLLIElement => {
     const li = document.createElement('li') as HTMLLIElement;
-    li.className = "list-group-item d-flex justify-content-space-between align-items-center";
+    li.className = CLASSES_CONTAINER_LI_EMPTY;
 
     const label = buildEmptyContainerLabelElement('No results');
 
     const icon = document.createElement('span');
-    icon.className = 'mono-16';
+    icon.className = CLASSES_CONTAINER_ICON_EMPTY_TEXT;
     icon.innerText = "x";
 
     li.appendChild(icon);
@@ -272,14 +278,14 @@ export const reflectSelected = (selected: SelectedContextIndex) => {
                 li.className = CLASSES_CONTAINER_LI_SELECTED;
             }
             if (urlLabel) {
-                urlLabel.className = containerListItemUrlLabelInverted;
+                urlLabel.className = CLASSES_CONTAINER_LI_URL_LABEL_INVERTED;
             }
         } else {
             if (li) {
                 li.className = CLASSES_CONTAINER_LI_INACTIVE;
             }
             if (urlLabel) {
-                urlLabel.className = containerListItemUrlLabel;
+                urlLabel.className = CLASSES_CONTAINER_LI_URL_LABEL;
             }
         }
     }

--- a/src/modules/elements.ts
+++ b/src/modules/elements.ts
@@ -10,7 +10,7 @@ import {
     CLASSES_CONTAINER_LI_URL_LABEL_INVERTED,
     CLASSES_CONTAINER_LI_URL_LABEL,
     CLASSES_CONTAINER_ICON_EMPTY_TEXT,
-    CLASSES_CONTAINER_ICON
+    CLASSES_CONTAINER_ICON,
 } from "./classes";
 import {
     MODES,
@@ -48,9 +48,14 @@ export const buildContainerIcon = (context: browser.contextualIdentities.Context
     iconDiv.className = CLASSES_CONTAINER_ICON_DIV;
 
     const icon = document.createElement('i') as HTMLElement;
-    icon.style.backgroundImage = `url(${context.iconUrl})`;
-    icon.style.backgroundRepeat = 'no-repeat';
-    icon.style.filter = `drop-shadow(${context.colorCode} 16px 0)`;
+    icon.style.webkitMaskSize = 'cover';
+    icon.style.maskSize = 'cover';
+    icon.style.webkitMaskImage = `url(${context.iconUrl})`;
+    icon.style.maskImage = `url(${context.iconUrl})`;
+    icon.style.backgroundColor = context.colorCode;
+    icon.style.width = '16px';
+    icon.style.height = '16px';
+    icon.style.display = 'inline-block';
     icon.className = CLASSES_CONTAINER_ICON;
 
     addEmptyEventListeners([iconDiv, icon]);
@@ -110,7 +115,12 @@ export const buildContainerLabel = async (
             } else {
                 urlLabel.innerText = `${url.substring(0, 40)}`;
             }
-
+        } else {
+            // maybe use this instead if it's ever needed - it just looks
+            // off-center though.
+            // urlLabel.innerHTML = '&nbsp;'
+            urlLabel.innerText = '-'
+            urlLabel.title = 'Opens in a blank container tab. Set a default URL to change this.';
         }
 
         const openCurrentPage = await getSetting(CONF.openCurrentPage) as boolean;

--- a/src/modules/events.ts
+++ b/src/modules/events.ts
@@ -1,7 +1,7 @@
 import { ActHandler, SelectedContextIndex } from "src/types";
-import { CLASSES_CONTAINER_LI_ACTIVE_DANGER, CLASSES_LI_ACTIVE, CLASSES_CONTAINER_LI_SELECTED, CLASSES_CONTAINER_LI_INACTIVE } from "./classes";
+import { CLASSES_CONTAINER_LI_URL_LABEL_INVERTED, CLASSES_CONTAINER_LI_URL_LABEL, CLASSES_CONTAINER_LI_ACTIVE_DANGER, CLASSES_CONTAINER_LI_ACTIVE, CLASSES_CONTAINER_LI_SELECTED, CLASSES_CONTAINER_LI_INACTIVE } from "./classes";
 import { getSetting } from "./config";
-import { MODES, containerListItemUrlLabelInverted, containerListItemUrlLabel, CONF } from "./constants";
+import { MODES, CONF } from "./constants";
 import { isContextSelected } from "./helpers";
 
 /**
@@ -63,10 +63,10 @@ export const setEventListeners = async (
                 return;
             }
 
-            target.className = CLASSES_LI_ACTIVE;
+            target.className = CLASSES_CONTAINER_LI_ACTIVE;
 
             const urlLabel = document.getElementById(urlLabelId) as HTMLSpanElement;
-            if (urlLabel) urlLabel.className = containerListItemUrlLabelInverted;
+            if (urlLabel) urlLabel.className = CLASSES_CONTAINER_LI_URL_LABEL_INVERTED;
         };
 
         const mouseLeave = async (event: MouseEvent) => {
@@ -80,14 +80,14 @@ export const setEventListeners = async (
 
             if (isContextSelected(i, selected)) {
                 target.className = CLASSES_CONTAINER_LI_SELECTED;
-                if (urlLabel) urlLabel.className = containerListItemUrlLabelInverted;
+                if (urlLabel) urlLabel.className = CLASSES_CONTAINER_LI_URL_LABEL_INVERTED;
 
                 return;
             }
 
             target.className = CLASSES_CONTAINER_LI_INACTIVE;
 
-            if (urlLabel) urlLabel.className = containerListItemUrlLabel;
+            if (urlLabel) urlLabel.className = CLASSES_CONTAINER_LI_URL_LABEL;
         }
 
         const onClick = (event: MouseEvent) => actHandler(filtered, context, event);
@@ -111,10 +111,10 @@ export const setEventListeners = async (
                 return;
             }
 
-            target.className = CLASSES_LI_ACTIVE;
+            target.className = CLASSES_CONTAINER_LI_ACTIVE;
 
             const urlLabel = document.getElementById(urlLabelId) as HTMLSpanElement;
-            if (urlLabel) urlLabel.className = containerListItemUrlLabel;
+            if (urlLabel) urlLabel.className = CLASSES_CONTAINER_LI_URL_LABEL;
         }
 
         const onBlur = async (event: FocusEvent) => {
@@ -132,7 +132,7 @@ export const setEventListeners = async (
             target.className = CLASSES_CONTAINER_LI_INACTIVE;
 
             const urlLabel = document.getElementById(urlLabelId) as HTMLSpanElement;
-            if (urlLabel) urlLabel.className = containerListItemUrlLabel;
+            if (urlLabel) urlLabel.className = CLASSES_CONTAINER_LI_URL_LABEL;
         }
 
         li.addEventListener('mouseover', mouseOver);

--- a/src/modules/html.ts
+++ b/src/modules/html.ts
@@ -49,7 +49,7 @@ export const helpful = async (mode?: MODES) => {
 
     switch (mode) {
         case MODES.SET_URL:
-            help("URLs do not affect multi-account container preferences.");
+            help("URLs are only set for this extension.");
             break;
         case MODES.SET_NAME:
             help("You will be prompted for a new name.")
@@ -65,7 +65,7 @@ export const helpful = async (mode?: MODES) => {
             help("You will be prompted for a new color.")
             break;
         case MODES.DUPLICATE:
-            help("Duplicates containers and URLs, but not cookies etc.")
+            help("Duplicates containers, URLs; not cookies")
             break;
         case MODES.DELETE:
             help("Warning: Will delete containers that you click");

--- a/src/modules/lib.ts
+++ b/src/modules/lib.ts
@@ -1103,7 +1103,7 @@ export const filter = async (
 
         await reflectFiltered(results, actualTabUrl);
 
-        bottomHelp(`Showing ${results.length}/${contexts.length} containers.`);
+        bottomHelp(`${results.length}/${contexts.length} shown`);
 
         if (event) {
             const keyboardEvent = event as KeyboardEvent;

--- a/src/popup.html
+++ b/src/popup.html
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-    <div class="container-fluid mt-3" id="mainDivContainer">
+    <div class="container-fluid p-2 m-0" id="mainDivContainer">
         <div class="modal modal-backdrop modal-hide" id="modal" tabindex="-1" role="dialog" aria-labelledby="modalTitle"
             aria-hidden="true">
             <div class="modal-dialog modal-dialog-centered" role="document">
@@ -60,9 +60,9 @@
             </div>
         </div>
         <form id="searchContainerForm">
-            <div class="form-group form-row">
+            <div class="form-group form-row mb-2 p-0">
                 <div class="col-12">
-                    <div class="input-group">
+                    <div class="input-group m-0 p-0">
                         <input type="text" class="form-control" placeholder="Search Containers"
                             id="searchContainerInput" />
                         <div class="input-group-append">
@@ -71,7 +71,7 @@
                     </div>
                 </div>
             </div>
-            <div class="form-group form-row">
+            <div class="form-group form-row mb-2 p-0">
                 <div class="col-12">
                     <select class="custom-select" id="modeSelect">
                         <option value="openOnClick" selected>1. Open as Tab(s)</option>
@@ -87,7 +87,7 @@
                     </select>
                 </div>
             </div>
-            <div class="form-group form-row">
+            <div class="form-group form-row mb-2 p-0">
                 <div class="col-12">
                     <select class="custom-select" id="sortModeSelect">
                         <option value="none" selected>Default Sort</option>
@@ -99,15 +99,15 @@
                     </select>
                 </div>
             </div>
-            <div class="form-row">
+            <div class="form-row m-0 p-0 mb-1">
                 <div class="col-12 d-flex justify-content-center align-items-center align-content-center">
-                    <div class="form-group form-check-inline small">
+                    <div class="form-group form-check-inline small m-0 mr-1 p-0">
                         <input type="checkbox" id="windowStayOpenState" class="form-check-input" checked="true">
                         <label for="windowStayOpenState" id="windowStayOpenStateLabel" class="form-check-label">
                             Sticky Popup
                         </label>
                     </div>
-                    <div class="form-group form-check-inline small">
+                    <div class="form-group form-check-inline small m-0 mr-1 p-0">
                         <input type="checkbox" id="selectionMode" class="form-check-input" checked="false">
                         <label for="selectionMode" id="selectionModeLabel" class="form-check-label">
                             Selection Mode
@@ -115,9 +115,9 @@
                     </div>
                 </div>
             </div>
-            <div class="form-row">
+            <div class="form-row m-0 p-0">
                 <div class="col-12 d-flex justify-content-center align-items-center align-content-center">
-                    <div class="form-group form-check-inline small">
+                    <div class="form-group form-check-inline small m-0 p-0">
                         <input type="checkbox" id="openCurrentPage" class="form-check-input" checked="false">
                         <label for="openCurrentPage" id="openCurrentPageLabel" class="form-check-label">
                             Override with current tab's URL
@@ -126,19 +126,19 @@
                 </div>
             </div>
         </form>
-        <div class="row">
+        <div class="row m-0 mb-1 p-0">
             <div class="col-12 text-center">
                 <span class="text-muted small" id="helpText"></span>
             </div>
         </div>
-        <div class="row">
-            <div class="col-12">
+        <div class="row m-0 p-0">
+            <div class="col-12 mx-0 px-0">
                 <div id="container-list" class="overflow-scroll-vertical"></div>
             </div>
         </div>
-        <div class="row">
+        <div class="row m-0 p-0">
             <div class="col-12 text-center text-muted">
-                <span class="text-muted text-center small" id="summaryText"></span><br />
+                <span class="text-muted text-center small" id="summaryText"></span> |
                 <span class="text-muted small">
                     <a href="https://github.com/cmcode-dev/firefox-containers-helper" target="_blank"
                         rel="noopener noreferrer">


### PR DESCRIPTION
Mentioned loosely in https://github.com/cmcode-dev/firefox-containers-helper/issues/39, this PR adjusts the classes/styling of the popup window to respect the fact that the maximum allowable height for an extension popup is 600px. There is now less space between elements to allow for more elements to vertically squeeze into the height constraints. Some other improvements have been made as well.
